### PR TITLE
Update internal links to new dirs

### DIFF
--- a/2017-procurement/SOLICITATION_README.md
+++ b/2017-procurement/SOLICITATION_README.md
@@ -14,33 +14,33 @@ The purpose of this solicitation is for the contractor to deliver a Bug Bounty p
 
 ### How to respond
 
-Detailed instructions about how to respond and how to use our [response templates](solicitation_documents/response_templates) are explained in [section 7.0 of our RFQ](solicitation_documents/001_RFQ.md#70-quotation-instructions).
+Detailed instructions about how to respond and how to use our [response templates](2017-procurement/response_templates) are explained in [section 7.0 of our RFQ](2017-procurement/001_RFQ.md#70-quotation-instructions).
 
 ### Key personnel
 
-Details about what we're looking for in a Technical Account Manager are explained in [section 6.1 of our PWS](solicitation_documents/003_PWS.md#61-key-personnel).
+Details about what we're looking for in a Technical Account Manager are explained in [section 6.1 of our PWS](2017-procurement/003_PWS.md#61-key-personnel).
 
 ### Period of performance
 
-There will be a Base Period of 3 months and two Option Periods of 3 months each. Details, including the official start date, are explained in [section 3.0 of our RFQ](solicitation_documents/001_RFQ.md#30-period-of-performance).
+There will be a Base Period of 3 months and two Option Periods of 3 months each. Details, including the official start date, are explained in [section 3.0 of our RFQ](2017-procurement/001_RFQ.md#30-period-of-performance).
 
 ## Contents
 
-1. [Request for Quotation (RFQ)](solicitation_documents/001_RFQ.md)
+1. [Request for Quotation (RFQ)](2017-procurement/001_RFQ.md)
 
-2. [Addendum](solicitation_documents/002_Addendum.md)
+2. [Addendum](2017-procurement/002_Addendum.md)
 
-3. [Performance Work Statement (PWS)](solicitation_documents/003_PWS.md)
+3. [Performance Work Statement (PWS)](2017-procurement/003_PWS.md)
 
-4. [Performance Based Quality Assurance Surveillance Plan (QASP)](solicitation_documents/004_QASP.md)
+4. [Performance Based Quality Assurance Surveillance Plan (QASP)](2017-procurement/004_QASP.md)
 
-5. [Technical File](solicitation_documents/response_templates/005_TECHNICAL_FILE.yaml)
+5. [Technical File](2017-procurement/response_templates/005_TECHNICAL_FILE.yaml)
 
-6. [Pricing File](solicitation_documents/response_templates/006_PRICING_FILE.yaml)
+6. [Pricing File](2017-procurement/response_templates/006_PRICING_FILE.yaml)
 
-7. [Signature File](solicitation_documents/response_templates/007_SIGNATURE_FILE.md)
+7. [Signature File](2017-procurement/response_templates/007_SIGNATURE_FILE.md)
 
-8. [SF30 Amendment 001](solicitation_documents/SF30-%20Bug%20Bounty-%20001.pdf)
+8. [SF30 Amendment 001](2017-procurement/SF30-%20Bug%20Bounty-%20001.pdf)
 
 ## Contributing
 

--- a/2017-procurement/acquisition_documents/Acquisition_Plan.md
+++ b/2017-procurement/acquisition_documents/Acquisition_Plan.md
@@ -56,7 +56,7 @@ Platforms typically provide triage services as a separate option, so this means 
 
 Most of the US government does not have a defined method by which vulnerabilities can be reported and the reporters rewarded. To address this situation for itself, TTS has recently released a vulnerability disclosure policy and needs to create a Bug Bounty program in order to incentivize security researchers and other interested users to report security issues directly to the system owner. While this policy and Bug Bounty program are specifically for TTS only - they will not involve GSA in general or the government as a whole - successful implementation will potentially serve as the model for other agencies.
 
-[The purpose](solicitation_documents/003_PWS.md#30-scope) of this solicitation, as stated in the Performance Work Statement (PWS), is for the contractor to deliver a Bug Bounty program which TTS will utilize for TTS-owned web applications. The contractor will provide access to their Bug Bounty SaaS Platform for researchers to report vulnerabilities (“Platform/Network Access”) and allow TTS to manage and track issues across multiple public web applications, triage services for those reported vulnerabilities, disburse rewards for effective vulnerabilities, and explain the reasons behind rejections (“Vulnerability Report Triage Services”).
+[The purpose](2017-procurement/003_PWS.md#30-scope) of this solicitation, as stated in the Performance Work Statement (PWS), is for the contractor to deliver a Bug Bounty program which TTS will utilize for TTS-owned web applications. The contractor will provide access to their Bug Bounty SaaS Platform for researchers to report vulnerabilities (“Platform/Network Access”) and allow TTS to manage and track issues across multiple public web applications, triage services for those reported vulnerabilities, disburse rewards for effective vulnerabilities, and explain the reasons behind rejections (“Vulnerability Report Triage Services”).
 
 For the Platform Access, GSA IT has already begun the approval process for the three known contractors in the industry. For the Vulnerability Report Triage Services, they must be provided on a “per web application” basis, allowing TTS to operate a Bug Bounty for a web application independently of the other web applications that are utilizing the Platform/Network Access for their own tests. As part of these services, the contractor must provide staff who are specialists in reviewing vulnerability reports and communicating with researchers.
 
@@ -124,7 +124,7 @@ Should-cost analysis, as defined in FAR Subpart 15.407-4, will not be performed 
 
 ## 7.105(a)(4) Capability or Performance Conditions
 
-The government will use the attached [Quality Assurance Surveillance Plan](solicitation_documents/004_QASP.md) (“QASP”) to monitor the contractor’s performance. The QASP will provide oversight help to ensure that service levels reach and maintain the required levels for performance of this task. Further, the QASP provides the government with a proactive way to avoid unacceptable or deficient performance, and provides verifiable input for the required Past Performance Information Assessments. The QASP is a living document and may be updated by the government as necessary. Any updates to the QASP will be provided to the contractor.
+The government will use the attached [Quality Assurance Surveillance Plan](2017-procurement/004_QASP.md) (“QASP”) to monitor the contractor’s performance. The QASP will provide oversight help to ensure that service levels reach and maintain the required levels for performance of this task. Further, the QASP provides the government with a proactive way to avoid unacceptable or deficient performance, and provides verifiable input for the required Past Performance Information Assessments. The QASP is a living document and may be updated by the government as necessary. Any updates to the QASP will be provided to the contractor.
 
 ## 7.105(a)(5) Delivery or Performance-period Requirements
 
@@ -390,7 +390,7 @@ This requirement does not include any inherently governmental or critical functi
 
 ## 7.105(b)(11) Management Information Requirements
 
-In accordance with the [Quality Assurance Surveillance Plan](solicitation_documents/004_QASP.md) (“QASP”), the government will management the contractor’s performance as detailed within the document.
+In accordance with the [Quality Assurance Surveillance Plan](2017-procurement/004_QASP.md) (“QASP”), the government will management the contractor’s performance as detailed within the document.
 
 ## 7.105(b)(12) Make or Buy
 
@@ -404,7 +404,7 @@ Finally, In accordance with [FAR 15.407-2(c)](https://www.acquisition.gov/sites/
 
 ## 7.105(b)(13) Test and Evaluation
 
-The [Quality Assurance Surveillance Plan](solicitation_documents/004_QASP.md) (“QASP”) specifies particular testing and documentation that the government has determined will lead to positive outcomes from the vendor.
+The [Quality Assurance Surveillance Plan](2017-procurement/004_QASP.md) (“QASP”) specifies particular testing and documentation that the government has determined will lead to positive outcomes from the vendor.
 
 ## 7.105(b)(14) Logistics Considerations
 
@@ -416,7 +416,7 @@ There are no contractor or agency support assumptions.
 
 The contractor shall indicate the warranty period and license period of any software provided throughout the life cycle of this purchase order requirement.
 
-The government will use a [Quality Assurance Surveillance Plan](solicitation_documents/004_QASP.md) (“QASP”) to monitor the contractor’s performance. The QASP will provide oversight help to ensure that service levels reach and maintain the required levels for performance of this task. Further, the QASP provides the government with a proactive way to avoid unacceptable or deficient performance, and provides verifiable input for the required Past Performance Information Assessments. The QASP is a living document and may be updated by the government as necessary. Any updates to the QASP will be provided to the contractor.
+The government will use a [Quality Assurance Surveillance Plan](2017-procurement/004_QASP.md) (“QASP”) to monitor the contractor’s performance. The QASP will provide oversight help to ensure that service levels reach and maintain the required levels for performance of this task. Further, the QASP provides the government with a proactive way to avoid unacceptable or deficient performance, and provides verifiable input for the required Past Performance Information Assessments. The QASP is a living document and may be updated by the government as necessary. Any updates to the QASP will be provided to the contractor.
 
 ### Data Rights and Ownership of Deliverables
 
@@ -475,11 +475,11 @@ This acquisition will be administered by the following individuals:
 
 ### Standard
 
-Please see Section 2.0 of the attached [Quality Assurance Surveillance Plan](solicitation_documents/004_QASP.md) (“QASP”).
+Please see Section 2.0 of the attached [Quality Assurance Surveillance Plan](2017-procurement/004_QASP.md) (“QASP”).
 
 ## 7.105(b)(20) Other Considerations
 
-[See attached Addendum with additional contract clauses](solicitation_documents/002_Addendum.md).
+[See attached Addendum with additional contract clauses](2017-procurement/002_Addendum.md).
 
 ## 7.105(b) (21) Milestones for the Acquisition Cycle Applicable Milestones
 

--- a/2018-procurement/RFQ.md
+++ b/2018-procurement/RFQ.md
@@ -1,6 +1,6 @@
 **General Services Administration **
 
-Federal Acquisition Service  
+Federal Acquisition Service
 Technology Transformation Services
 
 1800 F St NW | Washington, DC | 20405
@@ -11,10 +11,10 @@ Bug Bounty 2
 
 TCTOA-18-0013
 
-**From:** Michelle McNellis, Contracting Officer, GSA TTS  
+**From:** Michelle McNellis, Contracting Officer, GSA TTS
 **Subject:** Request for Quotation (RFQ)
 
-**Date:** July 24, 2018  
+**Date:** July 24, 2018
 **Reply By:** **August 07, 2018** **4:00PM EST**
 
 **Document Type:** Combined Synopsis/Solicitation Solicitation
@@ -212,15 +212,15 @@ will:
 
   - > Triage of severity of reported vulnerabilities. The contractor
     > will provide services to:
-    
+
       - > Screen reported vulnerabilities and filter out invalid and
         > duplicate reports.
-    
+
       - > Classify vulnerabilities according to TTS guidelines developed
         > for the vendor and assign them to the proper TTS staff, while
         > TTS maintains the rights to update these guidelines at any
         > time.
-    
+
       - > Communicate with researchers about their reports, escalating
         > to TTS staff if needed.
 
@@ -440,7 +440,7 @@ average time to triage a new report, average time to respond to
 researchers, average time to forward verified reports based on severity,
 etc.
 
-## 5.2 - Phase 2 Price Evaluation 
+## 5.2 - Phase 2 Price Evaluation
 
 Prices shall be submitted via the [<span class="underline">Price
 Evaluation Form</span>](https://goo.gl/forms/Vmvv6CRXLzMBpwLd2).
@@ -579,10 +579,10 @@ of price). During the performance of this task order, TTS may similarly
 publish data related to project management (e.g. user stories,
 milestones, and performance metrics) and top-line spending data.
 
-# 12.0 Attachments 
+# 12.0 Attachments
 
 [<span class="underline">See Addendum - Commercial Contract
-Clauses</span>](https://github.com/18F/tts-buy-bug-bounty/blob/master/solicitation_documents/Addendum%20-%20Commercial%20Contract%20Clauses.md)
+Clauses</span>](https://github.com/18F/tts-buy-bug-bounty/blob/master/2018-procurement/Addendum%20-%20Commercial%20Contract%20Clauses.md)
 
 [<span class="underline">Quality Assurance Surveillance
 Plan</span>](QASP.md)


### PR DESCRIPTION
This updates the procurement docs to point to the new directory names when linking internally. This also points to another ➕ for moving to absolute directories, since some of the docs in `previous_acquisition` were still linking internally to `solicitation_documents` (an easy mistake to have happen when using relative dirs).